### PR TITLE
Bump dependency to material-dialogs

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     compile 'com.facebook.react:react-native:0.14.+'
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile('com.github.afollestad.material-dialogs:core:0.8.5.0@aar') {
+    compile('com.github.afollestad.material-dialogs:core:0.8.5.8@aar') {
         transitive = true
     }
 }


### PR DESCRIPTION
Having trouble to download 0.8.5.0 from jitpack:

https://github.com/afollestad/material-dialogs/issues/818
